### PR TITLE
Align temperatures in reheat recipes to rest of the modpack

### DIFF
--- a/prototypes/updates/pypetroleumhandling-updates.lua
+++ b/prototypes/updates/pypetroleumhandling-updates.lua
@@ -78,11 +78,11 @@ RECIPE("guar-gum-plantation-mk04"):add_ingredient {type = "item", name = "metast
 RECIPE("tholin-capsule"):add_ingredient {type = "item", name = "cf", amount = 30}
 RECIPE("small-parts-03"):replace_ingredient("rubber", {type = "item", name = "cf", amount = 1})
 
-RECIPE("reheat-coke-gas"):replace_ingredient("combustion-mixture1", {type = "fluid", name = "hot-molten-salt", amount = 50, minimum_temperature = 995})
+RECIPE("reheat-coke-gas"):replace_ingredient("combustion-mixture1", {type = "fluid", name = "hot-molten-salt", amount = 50, minimum_temperature = 950})
 table.insert(RECIPE("reheat-coke-gas").results, {type = "fluid", name = "molten-salt", amount = 50})
 
 RECIPE("reheat-outlet-gas-1"):remove_unlock("hot-air-mk03"):set_fields {hidden = true}
-RECIPE("reheat-outlet-gas-2"):replace_ingredient("combustion-mixture1", {type = "fluid", name = "hot-molten-salt", amount = 50, minimum_temperature = 1995})
+RECIPE("reheat-outlet-gas-2"):replace_ingredient("combustion-mixture1", {type = "fluid", name = "hot-molten-salt", amount = 50, minimum_temperature = 1950})
 table.insert(RECIPE("reheat-outlet-gas-2").results, {type = "fluid", name = "molten-salt", amount = 50})
 
 RECIPE("fast-inserter-2"):replace_ingredient("electronic-circuit", {type = "item", name = "controler-mk01", amount = 2}):add_ingredient {type = "item", name = "electronics-mk01", amount = 2}:add_ingredient {type = "item", name = "gearbox-mk01", amount = 1}:replace_ingredient("steel-plate", "nbfe-alloy")


### PR DESCRIPTION
Other recipes requiring fluids at a certain temperature either use exact number or an offset of -50 (including all other recipes using molten salt with a temperature bound).

<img width="511" height="361" alt="image" src="https://github.com/user-attachments/assets/0042623e-2add-40ec-809d-ab58a2668336" />

This is an image of all fluids with temperature requirements used in the modpack. There is no way to get molten salt at >950 but below <995, or >1950 but below <1995, so the bounds can just be the same.